### PR TITLE
[CONSUL-167] Create windows image with Socat precompiled

### DIFF
--- a/test/integration/connect/envoy/Dockerfile-socat-windows
+++ b/test/integration/connect/envoy/Dockerfile-socat-windows
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/windows/servercore:1809
+
+RUN mkdir socat
+
+ENV SOCAT_URL=https://github.com/tech128/socat-1.7.3.0-windows/archive/refs/heads/master.zip
+RUN curl %SOCAT_URL% -L -o socat.zip
+
+RUN tar -xf socat.zip -C socat --strip-components=1
+
+ENV PATH C:\\socat;%PATH%
+
+ENTRYPOINT ["socat.exe"]

--- a/test/integration/connect/envoy/docker.windows.md
+++ b/test/integration/connect/envoy/docker.windows.md
@@ -4,6 +4,8 @@
 
 - [About](#about-this-file)
 - [Dockerfile-test-sds-server-windows](#dockerfile-test-sds-server-windows)
+- [Dockerfile-fortio-windows](#dockerfile-fortio-windows)
+- [Dockerfile-socat-windows](#dockerfile-socat-windows)
 
 ## About this File
 
@@ -14,13 +16,17 @@ In this file you will find which Dockerfiles are needed to run the Envoy integra
 This file sole purpose is to build the test-sds-server executable using Go. To do so, we use an official [golang image](https://hub.docker.com/_/golang/) provided in docker hub with Windows nano server.
 To build this image you need to run the following command on your terminal:
 
-`docker build -t test-sds-server -f Dockerfile-test-sds-server-windows test-sds-server`
+```Powershell
+docker build -t test-sds-server -f Dockerfile-test-sds-server-windows test-sds-server
+```
 
 This is the same command used in run-tests.sh
 
 You can test the built file by running the following command:
 
-`docker run --rm -p 1234:1234 --name test-sds-server test-sds-server:latest`
+```Powershell
+docker run --rm -p 1234:1234 --name test-sds-server test-sds-server
+```
 
 If everything works properly you should get the following output:
 
@@ -37,12 +43,42 @@ If everything works properly you should get the following output:
 This file sole purpose is to build the custom Fortio image for Windows OS. To do this, the official [windows/nanoserver image](https://hub.docker.com/_/microsoft-windows-nanoserver) is used as base image.
 To build this image you need to run the following command on your terminal:
 
-`docker build -t fortio . -f Dockerfile-fortio-windows`
+```Powershell
+docker build -t fortio . -f Dockerfile-fortio-windows
+```
 
 This is the same command used in run-tests.sh
 
 You can test the built file by running the following command:
 
-`docker run --rm -p 8080:8080 --name fortio fortio`
+```Powershell
+docker run --rm -p 8080:8080 --name fortio fortio
+```
 
 If everything works properly you should openning the browser and check that the Fortio server running on: `http://localhost:8080/fortio`
+
+## Dockerfile-socat-windows
+
+The alpine:socat image was replaced by a windows core image to which a precompiled version of Socat was installed.
+
+The windows base used was: `mcr.microsoft.com/windows/servercore:1809`
+
+The compiled windows version of Socat can be found in the repository [https://github.com/tech128/socat-1.7.3.0-windows](https://github.com/tech128/socat-1.7.3.0-windows)
+
+To build this image you need to run the following command on your terminal:
+
+```Powershell
+docker build -t socat -f Dockerfile-socat-windows .
+```
+
+You can test the built file by running the following command:
+
+```Powershell
+docker run --rm --name socat socat
+```
+
+If everything works properly you should get the following output:
+
+```Powershell
+20XX/XX/XX XX:XX:XX socat[1292] E exactly 2 addresses required (there are 0); use option "-h" for help
+```


### PR DESCRIPTION
### Description
Socat docker image creation with Windows

### Testing & Reproduction steps
Initially it would be necessary to test the manual start of the docker container: Example docker build -f Dockerfile-socat.windows -t socat .

### Links
The precompiled files from the repository are used:  [https://github.com/tech128/socat-1.7.3.0-windows](https://github.com/tech128/socat-1.7.3.0-windows)

### PR Checklist
