### PR TITLE
[CONSUL-212] Create/update dummy test case using jq or curl as output

### DIFF
--- a/test/integration/connect/envoy/Dockerfile-bats-windows
+++ b/test/integration/connect/envoy/Dockerfile-bats-windows
@@ -6,4 +6,7 @@ RUN choco install openssl -yf
 RUN choco install jq -yf
 
 COPY --from=fortio C:\\fortio C:\\fortio
+
 ENV PATH C:\\fortio;%PATH%
+ENV PATH C:\\Windows\\System32;%PATH%
+ENV PATH C:\\ProgramData\\chocolatey\\lib\\jq\\tools;%PATH%

--- a/test/integration/connect/envoy/case-dummy-bats/dummy-function.bash
+++ b/test/integration/connect/envoy/case-dummy-bats/dummy-function.bash
@@ -2,3 +2,15 @@ function dummyFunction {
   local LOCAL_VAR=$1
   echo $LOCAL_VAR $COMMON_VAR
 }
+
+function curlFunction {
+  STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" https://www.google.com)
+  echo $STATUS_CODE
+}
+
+function jqFunction {
+  INPUT_RAW_JSON=$1
+  KEY_TO_FIND=$2
+  RESULT=$(echo $INPUT_RAW_JSON | jq .$KEY_TO_FIND)
+  echo $RESULT
+}

--- a/test/integration/connect/envoy/case-dummy-bats/verify_2.bats
+++ b/test/integration/connect/envoy/case-dummy-bats/verify_2.bats
@@ -28,3 +28,20 @@ teardown() {
 
   [ "$status" -eq 100000 ]
 }
+
+@test "Test Function with Curl" {
+  run curlFunction
+
+  [ $status -eq 0 ]
+  [ -n "$output" ]
+  [ "$output" = "200" ]
+}
+
+@test "Test Function with jq" {
+  local INPUT='{"key1": "Test Value 1", "key2": "Test Value 2"}'
+  run jqFunction "$INPUT" "key1"
+
+  [ $status -eq 0 ]
+  [ -n "$output" ]
+  [ "$output" = "\"Test Value 1\"" ]
+}

--- a/test/integration/connect/envoy/docker.windows.md
+++ b/test/integration/connect/envoy/docker.windows.md
@@ -43,6 +43,8 @@ verify_1.bats
 verify_2.bats
     ✔ Test with dummyFunction invoked
     - Test skipped (skipped)
+    ✔ Test Function with Curl
+    ✔ Test Function with jq
 
 4 tests, 0 failures, 1 skipped
 ```


### PR DESCRIPTION
This PR intoroduces two new tests in the case-dummy-test using:
- **jq** to filter the value of a raw JSON and use it as output of the assertion
- **curl** to get status and use it as output of the assertion