### PR TITLE
[CONSUL-176] Support replacing CRLF by LF on scenarios scripts

### DIFF
--- a/build-support-windows/docker.windows.md
+++ b/build-support-windows/docker.windows.md
@@ -131,3 +131,25 @@ To build the images, it is necessary to open a Git bash terminal and run
 ```shell
 ./build-images.sh
 ```
+
+---
+# Testing
+
+During development, it may be more convenient to check your work-in-progress by running only the tests which you expect to be affected by your changes, as the full test suite can take several minutes to execute. [Go's built-in test tool](https://golang.org/pkg/cmd/go/internal/test/) allows specifying a list of packages to test and the `-run` option to only include test names matching a regular expression.
+The `go test -short` flag can also be used to skip slower tests.
+
+Examples (run from the repository root):
+
+- `go test -v ./connect` will run all tests in the connect package (see `./connect` folder)
+- `go test -v -run TestRetryJoin ./command/agent` will run all tests in the agent package (see `./command/agent` folder) with name substring `TestRetryJoin`
+
+When a pull request is opened CI will run all tests and lint to verify the change.
+
+If you want to run the tests on Windows images you must attach the win=true flag.
+
+Example:
+
+```shell
+go test -v -timeout=30m -tags integration ./test/integration/connect/envoy -run="TestEnvoy/case-badauthz" -win=true
+```
+

--- a/test/integration/connect/envoy/main_test.go
+++ b/test/integration/connect/envoy/main_test.go
@@ -5,7 +5,8 @@ package envoy
 
 import (
 	"flag"
-	"io/ioutil"
+    "io/ioutil"
+    "log"
 	"os"
 	"os/exec"
 	"sort"
@@ -21,6 +22,10 @@ var (
 
 func TestEnvoy(t *testing.T) {
 	flag.Parse()
+
+	if *flagWin == true {
+		travel_dir("../../../")
+	}
 
 	testcases, err := discoverCases()
 	require.NoError(t, err)
@@ -101,4 +106,58 @@ func discoverCases() ([]string, error) {
 
 	sort.Strings(out)
 	return out, nil
+}
+
+
+// crlf convert functions
+
+func travel_dir(path string ){
+    files, err := ioutil.ReadDir(path)
+    if err != nil {
+        log.Fatal(err)
+    }
+    for _, fil := range files {
+        
+        v := strings.Split(fil.Name(), ".")  
+        // names := v[0]
+        exts := v[len(v)-1]
+
+        file_path := path + "/" + fil.Name()
+
+        // if names.empty() == false {
+            if fil.IsDir() == true {
+                travel_dir(file_path)
+            }
+        // }
+
+        if exts == "sh" || exts == "bash" {
+            crlf_file_check(file_path)
+        }
+    }
+}
+
+func crlf_file_check(file_name string ){
+    
+    file, err := ioutil.ReadFile(file_name)
+    text := string(file)
+    
+    if edit := crlf_verify(text); edit != -1 {
+        crlf_normalize(file_name, text)
+    }
+    
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+
+func crlf_verify(text string ) int{
+    position := strings.Index(text, "\r\n"); 
+    return position
+}
+
+func crlf_normalize(filename, text string ) {
+    text = strings.Replace(text,"\r\n","\n",-1)
+    data := []byte(text)
+
+    ioutil.WriteFile(filename, data, 0644)
 }

--- a/test/integration/connect/envoy/main_test.go
+++ b/test/integration/connect/envoy/main_test.go
@@ -24,7 +24,8 @@ func TestEnvoy(t *testing.T) {
 	flag.Parse()
 
 	if *flagWin == true {
-		travel_dir("../../../")
+		dir := "../../../"
+		check_dir_files(dir)
 	}
 
 	testcases, err := discoverCases()
@@ -109,9 +110,10 @@ func discoverCases() ([]string, error) {
 }
 
 
-// crlf convert functions
-
-func travel_dir(path string ){
+// CRLF convert functions
+// Recursively iterates through the directory passed by parameter looking for the sh and bash files. 
+// Upon finding them, it calls crlf_file_check.
+func check_dir_files(path string) {
     files, err := ioutil.ReadDir(path)
     if err != nil {
         log.Fatal(err)
@@ -119,24 +121,22 @@ func travel_dir(path string ){
     for _, fil := range files {
         
         v := strings.Split(fil.Name(), ".")  
-        // names := v[0]
-        exts := v[len(v)-1]
+        file_extension := v[len(v)-1]
 
         file_path := path + "/" + fil.Name()
 
-        // if names.empty() == false {
-            if fil.IsDir() == true {
-                travel_dir(file_path)
-            }
-        // }
+        if fil.IsDir() == true {
+            check_dir_files(file_path)
+        }
 
-        if exts == "sh" || exts == "bash" {
+        if file_extension == "sh" || file_extension == "bash" {
             crlf_file_check(file_path)
         }
     }
 }
 
-func crlf_file_check(file_name string ){
+// Check if a file contains CRLF line endings if so call crlf_normalize
+func crlf_file_check(file_name string) {
     
     file, err := ioutil.ReadFile(file_name)
     text := string(file)
@@ -150,11 +150,13 @@ func crlf_file_check(file_name string ){
     }
 }
 
-func crlf_verify(text string ) int{
+// Checks for the existence of CRLF line endings.
+func crlf_verify(text string) int {
     position := strings.Index(text, "\r\n"); 
     return position
 }
 
+// Replace CRLF line endings with LF.
 func crlf_normalize(filename, text string ) {
     text = strings.Replace(text,"\r\n","\n",-1)
     data := []byte(text)


### PR DESCRIPTION
### Description
When running the tests, it must be verified that the bash and sh files are in the correct format. To do this, the directories are traversed and the line endings of those files are checked. If they are CRLF they are replaced by LF.

### PR Checklist

* [ ] find the files with crlf
* [ ] update files with crlf
* [ ] does not modify LF files
* [ ] do not modify files other than sh or bash

