### PR TITLE
[CONSUL-386] Remove Fortio & Envoy images check

### DIFF
--- a/Dockerfile-windows
+++ b/Dockerfile-windows
@@ -10,11 +10,6 @@ LABEL org.opencontainers.image.authors="Consul Team <consul@hashicorp.com>" \
       org.opencontainers.image.title="consul" \
       org.opencontainers.image.description="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration."
 
-# FROM envoyproxy/envoy-windows:v1.19.5 as envoy
-# COPY --from=envoy ["Program Files\envoy", "C:\envoy"]
-RUN mkdir C:\\envoy
-COPY build-support-windows/envoy.exe envoy/envoy.exe
-
 RUN ["powershell", "Set-ExecutionPolicy", "Bypass", "-Scope", "Process", "-Force;"]
 RUN ["powershell", "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"]
 
@@ -40,15 +35,6 @@ EXPOSE 8500 8600 8600/udp
 ENV CONSUL_URL=https://releases.hashicorp.com/consul/${VERSION}/consul_${VERSION}_windows_amd64.zip
 RUN curl %CONSUL_URL% -L -o consul.zip
 RUN tar -xf consul.zip -C consul
-
-RUN mkdir fortio
-
-ENV FORTIO_URL=https://github.com/fortio/fortio/releases/download/v1.33.0/fortio_win_1.33.0.zip
-RUN curl %FORTIO_URL% -L -o fortio.zip
-
-RUN tar -xf fortio.zip -C fortio
-
-ENV PATH C:\\Program Files\\Git\\bin;C:\\consul;C:\\Windows\\System32;C:\\fortio;C:\\envoy;%PATH%
 
 COPY .release/docker/docker-entrypoint-windows.sh C:\\docker-entrypoint-windows.sh
 ENTRYPOINT ["bash.exe", "docker-entrypoint-windows.sh"]

--- a/build-support-windows/Dockerfile-consul-dev-windows
+++ b/build-support-windows/Dockerfile-consul-dev-windows
@@ -1,3 +1,24 @@
 ARG CONSUL_IMAGE_VERSION=latest
 FROM windows/consul:${CONSUL_IMAGE_VERSION}
 COPY dist/ C:\\consul
+
+# Fortio binary downloaded
+RUN mkdir fortio
+ENV FORTIO_URL=https://github.com/fortio/fortio/releases/download/v1.33.0/fortio_win_1.33.0.zip
+RUN curl %FORTIO_URL% -L -o fortio.zip
+RUN tar -xf fortio.zip -C fortio
+
+# FROM envoyproxy/envoy-windows:v1.19.5 as envoy
+# COPY --from=envoy ["Program Files\envoy", "C:\envoy"]
+RUN mkdir C:\\envoy
+COPY envoy.exe envoy/envoy.exe
+
+EXPOSE 8300
+EXPOSE 8301 8301/udp 8302 8302/udp
+EXPOSE 8500 8600 8600/udp
+EXPOSE 8502 
+
+EXPOSE 19000 19001 19002 19003 19004
+EXPOSE 21000 21001 21002 21003 21004
+
+ENV PATH C:\\Program Files\\Git\\bin;C:\\consul;C:\\fortio;C:\\envoy;C:\\Windows\\System32;%PATH%

--- a/test/integration/connect/envoy/Dockerfile-bats-windows
+++ b/test/integration/connect/envoy/Dockerfile-bats-windows
@@ -1,10 +1,6 @@
-FROM docker.mirror.hashicorp.services/windows/fortio AS fortio
-
 FROM docker.mirror.hashicorp.services/windows/bats:1.7.0
 
 RUN choco install openssl -yf
 RUN choco install jq -yf
 
-COPY --from=fortio C:\\fortio C:\\fortio
-
-ENV PATH C:\\Windows\\System32;C:\\fortio;C:\\ProgramData\\chocolatey\\lib\\jq\\tools;C:\\Program Files\\OpenSSL-Win64\\bin;%PATH%
+ENV PATH C:\\Windows\\System32;C:\\ProgramData\\chocolatey\\lib\\jq\\tools;C:\\Program Files\\OpenSSL-Win64\\bin;%PATH%

--- a/test/integration/connect/envoy/helpers.windows.bash
+++ b/test/integration/connect/envoy/helpers.windows.bash
@@ -839,7 +839,7 @@ function gen_envoy_bootstrap {
     -envoy-version "$ENVOY_VERSION" \
     -http-addr envoy_consul-${DC}_1:8500 \
     -grpc-addr envoy_consul-${DC}_1:8502 \
-    -admin-access-log-path C:\\log \
+    -admin-access-log-path="C:/envoy/envoy.log" \
     -admin-bind 0.0.0.0:$ADMIN_PORT ${EXTRA_ENVOY_BS_ARGS}); then
     
     # All OK, write config to file

--- a/test/integration/connect/envoy/run-tests.windows.sh
+++ b/test/integration/connect/envoy/run-tests.windows.sh
@@ -572,12 +572,6 @@ function suite_setup {
     echo "Checking bats image..."
     docker.exe run --rm -t bats-verify -v
 
-    # pre-build the consul+envoy container
-    echo "Rebuilding 'consul-dev-envoy:v${ENVOY_VERSION}' image..."
-    docker.exe build -t consul-dev-envoy:v${ENVOY_VERSION} \
-         --build-arg ENVOY_VERSION=${ENVOY_VERSION} \
-         -f Dockerfile-consul-envoy-windows .
-
     # pre-build the test-sds-server container
     echo "Rebuilding 'test-sds-server' image..."
     docker.exe build -t test-sds-server -f Dockerfile-test-sds-server-windows test-sds-server


### PR DESCRIPTION
### Description
This PR introduces the changes to:
- Remove the build of consul-envoy image from `run-test-windows.sh` file
- Move stages of Downloading Fortio binary and copy envoy binary to `Dockerfile-consul-dev-windows`
- Minor fix in the command that create the bootstrap file in `generate_envoy_bootstrap` function of the `helpers.windows.bash` file

