### PR TITLE
[CONSUL-410] Run Jaeger in Single container

### DIFF
--- a/build-support-windows/Dockerfile-consul-dev-windows
+++ b/build-support-windows/Dockerfile-consul-dev-windows
@@ -24,6 +24,12 @@ RUN mkdir bats-core
 RUN tar -xf bats.zip -C bats-core --strip-components=1
 RUN cd "C:\\Program Files\\Git\\bin" && bash.exe -c "/c/bats-core/install.sh /c/bats"
 
+# Install Jaeger
+ENV JAEGER_URL=https://github.com/jaegertracing/jaeger/releases/download/v1.11.0/jaeger-1.11.0-windows-amd64.tar.gz
+RUN curl %JAEGER_URL% -L -o jaeger.tar.gz
+RUN mkdir jaeger
+RUN tar -xf jaeger.tar.gz -C jaeger --strip-components=1
+
 EXPOSE 8300
 EXPOSE 8301 8301/udp 8302 8302/udp
 EXPOSE 8500 8600 8600/udp
@@ -33,4 +39,4 @@ EXPOSE 19000 19001 19002 19003 19004
 EXPOSE 21000 21001 21002 21003 21004
 EXPOSE 5000 1234 2345
 
-RUN SETX /M path "%PATH%;C:\consul;C:\envoy;C:\fortio;C:\Program Files\Git\bin;C:\Program Files\OpenSSL-Win64\bin;C:\bats\bin\bats;C:\ProgramData\chocolatey\lib\jq\tools;"
+RUN SETX /M path "%PATH%;C:\consul;C:\envoy;C:\fortio;C:\jaeger;C:\Program Files\Git\bin;C:\Program Files\OpenSSL-Win64\bin;C:\bats\bin\bats;C:\ProgramData\chocolatey\lib\jq\tools;"

--- a/test/integration/connect/envoy/case-zipkin/verify.bats
+++ b/test/integration/connect/envoy/case-zipkin/verify.bats
@@ -37,14 +37,17 @@ load helpers
   # Send traced request through upstream. Debug echoes headers back which we can
   # use to get the traceID generated (no way to force one I can find with Envoy
   # currently?)
-  run curl -s -f -H 'x-client-trace-id:test-sentinel' localhost:5000/Debug
+  # Fixed from /Debug -> /debug. Reason: /Debug return null
+  run curl -s -f -H 'x-client-trace-id:test-sentinel' localhost:5000/debug
 
   echo "OUTPUT $output"
 
   [ "$status" == "0" ]
 
   # Get the traceID from the output
-  TRACEID=$(echo $output | grep 'X-B3-Traceid:' | cut -c 15-)
+  # Replaced grep by jq to filter the TraceId.
+  # Reason: Grep did not filter and return the entire raw string and the test was failing
+  TRACEID=$(echo $output | jq -rR 'split("X-B3-Traceid: ") | last' | cut -c -16)
 
   # Get the trace from Jaeger. Won't bother parsing it just seeing it show up
   # there is enough to know that the tracing config worked.

--- a/test/integration/connect/envoy/run-tests.windows.sh
+++ b/test/integration/connect/envoy/run-tests.windows.sh
@@ -599,7 +599,7 @@ function common_run_container_service {
   local grpcPort="$4"
   local CONTAINER_NAME="$SINGLE_CONTAINER_BASE_NAME"-"$CLUSTER"_1
 
-  docker.exe exec -d $CONTAINER_NAME bash -c "FORTIO_NAME=${service} &&
+  docker.exe exec -d $CONTAINER_NAME bash -c "FORTIO_NAME=${service} \
                                               fortio.exe server \
                                               -http-port ":$httpPort" \
                                               -grpc-port ":$grpcPort" \
@@ -811,11 +811,11 @@ function run_container_zipkin {
 }
 
 function run_container_jaeger {
-  docker.exe run -d --name $(container_name) \
-    $WORKDIR_SNIPPET \
-    $(network_snippet primary) \
-    "${HASHICORP_DOCKER_PROXY}/windows/jaegertracing" \
-    --collector.zipkin.http-port=9411
+  local DC=${1:-primary}
+  local CONTAINER_NAME="$SINGLE_CONTAINER_BASE_NAME"-"$DC"_1
+
+  docker.exe exec -d $CONTAINER_NAME bash -c "jaeger-all-in-one.exe \
+                                              --collector.zipkin.http-port=9411"
 }
 
 function run_container_test-sds-server {


### PR DESCRIPTION
### Description
This PR introduces the changes to run Jaeger inside of the single container. This is because the test attempt to make a request to localhost:16686 which belongs to the Jaeger server but it's running in a different container. With this change, now the server is running in same container and the request to localhost:16686 is working

In addition the PR introduces a minor fix in the last test of the `case-zipkin` test case to:
- Use the route localhost:5000/debug instead of localhost:5000/Debug to make the first request. This is because with /Debug, the response came empty
- filter the `traceId` using `jq` instead of `grep`. Previously with grep, the command was not filtering correctly the substring

![image](https://user-images.githubusercontent.com/25471865/188707650-89a2c246-d973-4343-926c-c7ab24bdd87b.png)

