### PR TITLE
[CONSUL-412] Run test-sds-server in single container

### DIFF
--- a/build-support-windows/Dockerfile-consul-dev-windows
+++ b/build-support-windows/Dockerfile-consul-dev-windows
@@ -17,9 +17,9 @@ COPY --from=envoy ["C:/Program Files/envoy/", "C:/envoy/"]
 RUN choco install openssl -yf
 RUN choco install jq -yf
 
+# Install Bats
 ENV BATS_URL=https://github.com/bats-core/bats-core/archive/refs/tags/v1.7.0.zip
 RUN curl %BATS_URL% -L -o bats.zip
-
 RUN mkdir bats-core
 RUN tar -xf bats.zip -C bats-core --strip-components=1
 RUN cd "C:\\Program Files\\Git\\bin" && bash.exe -c "/c/bats-core/install.sh /c/bats"
@@ -29,6 +29,9 @@ ENV JAEGER_URL=https://github.com/jaegertracing/jaeger/releases/download/v1.11.0
 RUN curl %JAEGER_URL% -L -o jaeger.tar.gz
 RUN mkdir jaeger
 RUN tar -xf jaeger.tar.gz -C jaeger --strip-components=1
+
+# Copy test-sds-server binary and certs
+COPY --from=test-sds-server ["C:/go/src/", "C:/test-sds-server/"]
 
 EXPOSE 8300
 EXPOSE 8301 8301/udp 8302 8302/udp

--- a/test/integration/connect/envoy/Dockerfile-test-sds-server-windows
+++ b/test/integration/connect/envoy/Dockerfile-test-sds-server-windows
@@ -3,6 +3,6 @@ FROM golang:1.18.1-nanoserver-1809
 WORKDIR /go/src
 COPY ./ .
 
-RUN go build -v -o test-sds-server sds.go
+RUN go build -v -o test-sds-server.exe sds.go
 
-CMD ["/go/src/test-sds-server"]
+CMD ["test-sds-server.exe"]

--- a/test/integration/connect/envoy/run-tests.windows.sh
+++ b/test/integration/connect/envoy/run-tests.windows.sh
@@ -60,7 +60,6 @@ function init_workdir {
   # don't wipe logs between runs as they are already split and we need them to
   # upload as artifacts later.
   rm -rf workdir/${CLUSTER}
-  rm -rf workdir/logs
   mkdir -p workdir/${CLUSTER}/{consul,consul-server,register,envoy,bats,statsd,data}
 
   # Reload consul config from defaults
@@ -243,8 +242,6 @@ function start_consul {
     docker.exe run -d --name envoy_consul-${DC}_1 \
       --net=envoy-tests \
       $WORKDIR_SNIPPET \
-      --memory 4096m \
-      --cpus 2 \
       --hostname "consul-${DC}" \
       --network-alias "consul-${DC}-client" \
       --network-alias "consul-${DC}-server" \


### PR DESCRIPTION
### Description
- This PR introduces the changes to:
- Copy the `test-sds-server` binary and the `certs` folder from the pre-built image inside of the `windows/consul-dev` image
- Run the test-sds-server inside of the single container instead of creating it as new one.
- Fix the certificate path used in the case-ingres-gateway-sds test case. On Linux OS it's `/workdir/test-sds-server/certificates` menawhile on Windows it's `/c/workdir/test-sds-server/certificates`

