### PR TITLE
[CONSUL-434] Replace Docker run functions in Helpers bash script

### DIFF
--- a/test/integration/connect/envoy/run-tests.windows.sh
+++ b/test/integration/connect/envoy/run-tests.windows.sh
@@ -529,8 +529,6 @@ function run_tests {
     pre_service_setup alpha
   fi
 
-  stop_and_copy_files
-
   echo "Starting services"
   start_services
 


### PR DESCRIPTION
### Description
This PR modifies the function to execute Docker exec instead of Docker run in next functions of the Helpers bash script:
- gen_envoy_bootstrap
- read_config_entry
- setup_upsert_l4_intention