### PR TITLE
[CONSUL-429] Replace Docker run with Docker exec in run_container_fake-statsd Function

### DIFF
--- a/build-support-windows/Dockerfile-consul-local-windows
+++ b/build-support-windows/Dockerfile-consul-local-windows
@@ -49,4 +49,4 @@ EXPOSE 19000 19001 19002 19003 19004
 EXPOSE 21000 21001 21002 21003 21004
 EXPOSE 5000 1234 2345
 
-RUN SETX /M path "%PATH%;C:\consul;C:\envoy;C:\fortio;C:\jaeger;C:\Program Files\Git\bin;C:\Program Files\OpenSSL-Win64\bin;C:\bats\bin\bats;C:\ProgramData\chocolatey\lib\jq\tools;C:\socat;"
+RUN SETX /M path "%PATH%;C:\consul;C:\envoy;C:\fortio;C:\jaeger;C:\Program Files\Git\bin;C:\Program Files\Git\usr\bin;C:\Program Files\OpenSSL-Win64\bin;C:\bats\bin\;C:\ProgramData\chocolatey\lib\jq\tools;C:\socat;"

--- a/test/integration/connect/envoy/helpers.windows.bash
+++ b/test/integration/connect/envoy/helpers.windows.bash
@@ -615,10 +615,21 @@ function kill_envoy {
   tskill $PID
 }
 
+# This function is needed since socats SYSTEM isn't working. 
+function split_lines_in_stats {
+  local MATCH=$1
+  local FILE=$2
+
+  sed -i "s/$MATCH/\n$MATCH/g" $FILE
+}
+
 function must_match_in_statsd_logs {
   local DC=${2:-primary}
+  local FILE="/c/workdir/${DC}/statsd/statsd.log"
 
-  run cat /workdir/${DC}/statsd/statsd.log
+  split_lines_in_stats envoy $FILE 
+
+  run cat $FILE
   echo "$output"
   COUNT=$( echo "$output" | grep -Ec $1 )
 

--- a/test/integration/connect/envoy/run-tests.windows.sh
+++ b/test/integration/connect/envoy/run-tests.windows.sh
@@ -803,15 +803,11 @@ function run_container_terminating-gateway-primary {
 }
 
 function run_container_fake-statsd {
+  local CONTAINER_NAME="$SINGLE_CONTAINER_BASE_NAME"-"primary"_1
   # This magic SYSTEM incantation is needed since Envoy doesn't add newlines and so
   # we need each packet to be passed to echo to add a new line before
-  # appending.
-  docker.exe run -d --name $(container_name) \
-    $WORKDIR_SNIPPET \
-    $(network_snippet primary) \
-    "${HASHICORP_DOCKER_PROXY}/windows/socat" \
-    -u UDP-RECVFROM:8125,fork,reuseaddr \
-    SYSTEM:'xargs -0 echo >> /workdir/primary/statsd/statsd.log'
+  # appending. But it does not work on Windows.   
+  docker.exe exec -d $CONTAINER_NAME bash -c "socat -u UDP-RECVFROM:8125,fork,reuseaddr OPEN:/workdir/primary/statsd/statsd.log,create,append"                                            
 }
 
 function run_container_zipkin {


### PR DESCRIPTION
## Changes in run-tests.windows.sh
- Updated run_container_fake-statsd to use docker exec instead of docker run.
- Updated the docker exec command since SYSTEM was not working on Windows.
## Changes in helpers.windows.bash
- Created a function to split the new statsd.log file from 1 line into multiple lines.
- Updated must_match_in_statsd_logs function to use the newly created function.