### PR TITLE
[CONSUL-443] Create dogstatsd Function

### DIFF
--- a/test/integration/connect/envoy/case-dogstatsd-udp/verify.bats
+++ b/test/integration/connect/envoy/case-dogstatsd-udp/verify.bats
@@ -29,14 +29,11 @@ load helpers
 }
 
 @test "s1 proxy should be sending metrics to statsd" {
-  run retry_default cat /workdir/primary/statsd/statsd.log
+  run retry_default must_match_in_statsd_logs '^envoy\.' primary  
 
-  echo "METRICS:"
-  echo "$output"
-  echo "COUNT: $(echo "$output" | grep -Ec '^envoy\.')"
+  echo "METRICS: $output"
 
-  [ "$status" == 0 ]
-  [ $(echo $output | grep -Ec '^envoy\.') -gt "0" ]
+  [ "$status" == 0 ]  
 }
 
 @test "s1 proxy should be sending dogstatsd tagged metrics" {

--- a/test/integration/connect/envoy/helpers.windows.bash
+++ b/test/integration/connect/envoy/helpers.windows.bash
@@ -623,8 +623,13 @@ function kill_envoy {
 function split_lines_in_stats {
   local MATCH=$1
   local FILE=$2
-
-  sed -i "s/$MATCH/\n$MATCH/g" $FILE
+  local LINE_COUNT=$( sed -n '$=' $FILE )
+  if [[ $LINE_COUNT == "1" ]]
+  then
+    sed -i "s/$MATCH/\n$MATCH/g" $FILE
+  else
+    return 0
+  fi    
 }
 
 function must_match_in_statsd_logs {


### PR DESCRIPTION
### Description
- Updated function in helpers.windows.bash to only execute changes in log files with only 1 line of content.
- Changed test in case-dogstatsd-udp to use must_match_in_statsd_logs for two reasons:
  -  First, the path used originally to execute cat on, is only valid on Linux
  -  Secondly, we need to split the content of the log file into lines before filtering its content using grep.