### PR TITLE
[CONSUL-461] Test Wipe Volumes Without Extra Container

### DIFF
--- a/test/integration/connect/envoy/run-tests.windows.sh
+++ b/test/integration/connect/envoy/run-tests.windows.sh
@@ -440,11 +440,7 @@ function global_setup {
 }
 
 function wipe_volumes {
-  docker.exe run --rm -i \
-    $WORKDIR_SNIPPET \
-    --net=none \
-    "${HASHICORP_DOCKER_PROXY}/windows/nanoserver" \
-    cmd rd /s /q "C:\\workdir"
+  docker.exe exec -w "C:\workdir" envoy_workdir_1 cmd /c "rd /s /q . 2>nul"
 }
 
 # Windows containers does not allow cp command while running.


### PR DESCRIPTION
### Description
Replace docker run with docker exec to remove all data stored inside workdir before running each test case.