### PR TITLE
[CONSUL-466] Review case-grpc Failing Test

### DIFF
--- a/test/integration/connect/envoy/case-grpc/service_s1.hcl
+++ b/test/integration/connect/envoy/case-grpc/service_s1.hcl
@@ -17,7 +17,7 @@ services {
           protocol = "grpc"
           envoy_dogstatsd_url = "udp://127.0.0.1:8125"
           envoy_stats_tags = ["foo=bar"]
-          envoy_stats_flush_interval = "1s"
+          envoy_stats_flush_interval = "5s"
         }
       }
     }

--- a/test/integration/connect/envoy/case-grpc/verify.bats
+++ b/test/integration/connect/envoy/case-grpc/verify.bats
@@ -43,7 +43,7 @@ load helpers
     metrics_query='envoy.cluster.grpc.PingServer.total.*[#,]local_cluster:s1(,|$)'
   fi
 
-  run retry_default must_match_in_statsd_logs "${metrics_query}"
+  run retry_long must_match_in_statsd_logs "${metrics_query}"
   echo "OUTPUT: $output"
 
   [ "$status" == 0 ]

--- a/test/integration/connect/envoy/helpers.windows.bash
+++ b/test/integration/connect/envoy/helpers.windows.bash
@@ -642,32 +642,13 @@ function kill_envoy {
   tskill $PID
 }
 
-# This function is needed since socats SYSTEM isn't working. 
-function split_lines_in_stats {
-  local MATCH=$1
-  local FILE=$2
-  local LINE_COUNT=$( sed -n '$=' $FILE )
-  if [[ $LINE_COUNT == "1" ]]
-  then
-    sed -i "s/$MATCH/\n$MATCH/g" $FILE
-  else
-    return 0
-  fi    
-}
-
 function must_match_in_statsd_logs {
   local DC=${2:-primary}
   local FILE="/c/workdir/${DC}/statsd/statsd.log"
-
-  split_lines_in_stats envoy $FILE 
-
-  run cat $FILE
-  echo "$output"
-  COUNT=$( echo "$output" | grep -Ec $1 )
-
+  
+  COUNT=$( grep -Ec $1 $FILE )  
   echo "COUNT of '$1' matches: $COUNT"
-
-  [ "$status" == 0 ]
+ 
   [ "$COUNT" -gt "0" ]
 }
 


### PR DESCRIPTION
### Description
- Deleted unused functions
- Replaced retry_default for retry_long on failing test.
- Updated must_match_in_statsd_logs functions to perform grep directly on the logs file.
- Increased envoy_stats_flush_interval from 1s to 5s.

Everything was tested both on Linux and Windows. This test is now passing.

