### PR TITLE
[CONSUL-505] Change admin_bind in gen_envoy_bootstrap function

### DIFF
--- a/test/integration/connect/envoy/helpers.windows.bash
+++ b/test/integration/connect/envoy/helpers.windows.bash
@@ -779,11 +779,13 @@ function gen_envoy_bootstrap {
   DC=${3:-primary}
   IS_GW=${4:-0}
   EXTRA_ENVOY_BS_ARGS="${5-}"
+  ADMIN_HOST="0.0.0.0"
 
   PROXY_ID="$SERVICE"
   if ! is_set "$IS_GW"
   then
     PROXY_ID="$SERVICE-sidecar-proxy"
+    ADMIN_HOST="127.0.0.1"
   fi
 
   if output=$(docker_consul_for_proxy_bootstrap $DC "consul connect envoy -bootstrap \
@@ -792,7 +794,7 @@ function gen_envoy_bootstrap {
     -http-addr envoy_consul-${DC}_1:8500 \
     -grpc-addr envoy_consul-${DC}_1:8502 \
     -admin-access-log-path="C:/envoy/envoy.log" \
-    -admin-bind 127.0.0.1:$ADMIN_PORT ${EXTRA_ENVOY_BS_ARGS} \
+    -admin-bind $ADMIN_HOST:$ADMIN_PORT ${EXTRA_ENVOY_BS_ARGS} \
     > /c/workdir/${DC}/envoy/${SERVICE}-bootstrap.json 2>&1"); then
     # All OK, write config to file
     echo "$output" > workdir/${DC}/envoy/$SERVICE-bootstrap.json

--- a/test/integration/connect/envoy/run-tests.windows.sh
+++ b/test/integration/connect/envoy/run-tests.windows.sh
@@ -230,7 +230,7 @@ function start_consul {
       $WORKDIR_SNIPPET \
       --hostname "consul-${DC}-server" \
       --network-alias "consul-${DC}-server" \
-      -e "CONSUL_LICENSE=$license" \     
+      -e "CONSUL_LICENSE=$license" \
       windows/consul:local \
       agent -dev -datacenter "${DC}" \
       -config-dir "C:\\workdir\\${DC}\\consul" \

--- a/test/integration/connect/envoy/run-tests.windows.sh
+++ b/test/integration/connect/envoy/run-tests.windows.sh
@@ -150,23 +150,21 @@ function start_consul {
   # 8500/8502 are for consul
   # 9411 is for zipkin which shares the network with consul
   # 16686 is for jaeger ui which also shares the network with consul
-  server_ports=(
+ ports=(
     '-p=8500:8500'
     '-p=8502:8502'
-  )
-  agent_ports=(
     '-p=9411:9411'
     '-p=16686:16686'
   )
   case "$DC" in
     secondary)
-      server_ports=(
+      ports=(
         '-p=9500:8500'
         '-p=9502:8502'
       )
       ;;
     alpha)
-      server_ports=(
+      ports=(
         '-p=9510:8500'
         '-p=9512:8502'
       )
@@ -232,8 +230,7 @@ function start_consul {
       $WORKDIR_SNIPPET \
       --hostname "consul-${DC}-server" \
       --network-alias "consul-${DC}-server" \
-      -e "CONSUL_LICENSE=$license" \
-      ${server_ports[@]} \
+      -e "CONSUL_LICENSE=$license" \     
       windows/consul:local \
       agent -dev -datacenter "${DC}" \
       -config-dir "C:\\workdir\\${DC}\\consul" \
@@ -248,7 +245,7 @@ function start_consul {
       --hostname "consul-${DC}-client" \
       --network-alias "consul-${DC}-client" \
       -e "CONSUL_LICENSE=$license" \
-      ${agent_ports[@]} \
+      ${ports[@]} \
       windows/consul:local \
       agent -datacenter "${DC}" \
       -config-dir "C:\\workdir\\${DC}\\consul" \
@@ -269,7 +266,7 @@ function start_consul {
       --network-alias "consul-${DC}-client" \
       --network-alias "consul-${DC}-server" \
       -e "CONSUL_LICENSE=$license" \
-      ${server_ports[@]} ${agent_ports[@]} \
+      ${ports[@]} \
       windows/consul:local \
       agent -dev -datacenter "${DC}" \
       -config-dir "C:\\workdir\\${DC}\\consul" \


### PR DESCRIPTION
### Description
- Reverted changes in published ports in run-tests.windows.sh 
- Added functionality to gen_envoy_bootstrap function: if it is a gateway proxy Envoy's admin is bound to 0.0.0.0, if it is a sidecar proxy it will be bound to 127.0.0.1.
