### PR TITLE
[CONSUL-514] Add zipkin to Docker Image

### DIFF
--- a/build-support-windows/Dockerfile-consul-local-windows
+++ b/build-support-windows/Dockerfile-consul-local-windows
@@ -1,6 +1,7 @@
 ARG VERSION=1.13.1
 
 FROM windows/test-sds-server as test-sds-server
+FROM docker.mirror.hashicorp.services/windows/openzipkin as openzipkin
 FROM windows/consul:${VERSION}
 
 # Fortio binary downloaded
@@ -35,6 +36,10 @@ RUN tar -xf socat.zip -C socat --strip-components=1
 # Copy test-sds-server binary and certs
 COPY --from=test-sds-server ["C:/go/src/", "C:/test-sds-server/"]
 
+# Copy openzipkin .jar file
+COPY --from=openzipkin ["C:/zipkin", "C:/zipkin"]
+COPY --from=openzipkin ["C:/openjdk-18", "C:/openjdk-18"]
+
 EXPOSE 8300
 EXPOSE 8301 8301/udp 8302 8302/udp
 EXPOSE 8500 8600 8600/udp
@@ -44,4 +49,4 @@ EXPOSE 19000 19001 19002 19003 19004
 EXPOSE 21000 21001 21002 21003 21004
 EXPOSE 5000 1234 2345
 
-RUN SETX /M path "%PATH%;C:\consul;C:\fortio;C:\jaeger;C:\Program Files\Git\bin;C:\Program Files\Git\usr\bin;C:\Program Files\OpenSSL-Win64\bin;C:\bats\bin\;C:\ProgramData\chocolatey\lib\jq\tools;C:\socat;"
+RUN SETX /M path "%PATH%;C:\consul;C:\fortio;C:\jaeger;C:\Program Files\Git\bin;C:\Program Files\Git\usr\bin;C:\Program Files\OpenSSL-Win64\bin;C:\bats\bin\;C:\ProgramData\chocolatey\lib\jq\tools;C:\socat;C:\openjdk-18\bin"

--- a/build-support-windows/Dockerfile-openzipkin-windows
+++ b/build-support-windows/Dockerfile-openzipkin-windows
@@ -1,9 +1,12 @@
 FROM docker.mirror.hashicorp.services/windows/openjdk:1809
 
-RUN curl.exe -sSL 'https://search.maven.org/remote_content?g=io.zipkin&a=zipkin-server&v=LATEST&c=exec' -o zipkin.jar
+RUN mkdir zipkin
+RUN curl.exe -sSL 'https://search.maven.org/remote_content?g=io.zipkin&a=zipkin-server&v=LATEST&c=exec' -o zipkin/zipkin.jar
 
 EXPOSE 9410/tcp
 
 EXPOSE 9411/tcp
+
+WORKDIR /zipkin
 
 ENTRYPOINT ["java", "-jar", "zipkin.jar"]


### PR DESCRIPTION
### Description
- Updated Dockerfile-consul-local-windows to copy openJDK and openzipkin.jar, also, updated the PATH adding Java.