### PR TITLE
[CONSUL-543] Create exec_supported.go

### DIFF
--- a/command/connect/envoy/exec_supported.go
+++ b/command/connect/envoy/exec_supported.go
@@ -1,0 +1,60 @@
+//go:build linux || darwin || windows
+// +build linux darwin windows
+
+package envoy
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// testSelfExecOverride is a way for the tests to no fork-bomb themselves by
+// self-executing the whole test suite for each case recursively. It's gross but
+// the least gross option I could think of.
+var testSelfExecOverride string
+
+func isHotRestartOption(s string) bool {
+	restartOpts := []string{
+		"--restart-epoch",
+		"--hot-restart-version",
+		"--drain-time-s",
+		"--parent-shutdown-time-s",
+	}
+	for _, opt := range restartOpts {
+		if s == opt {
+			return true
+		}
+		if strings.HasPrefix(s, opt+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasHotRestartOption(argSets ...[]string) bool {
+	for _, args := range argSets {
+		for _, opt := range args {
+			if isHotRestartOption(opt) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// execArgs returns the command and args used to execute a binary. By default it
+// will return a command of os.Executable with the args unmodified. This is a shim
+// for testing, and can be overridden to execute using 'go run' instead.
+var execArgs = func(args ...string) (string, []string, error) {
+	execPath, err := os.Executable()
+	if err != nil {
+		return "", nil, err
+	}
+
+	if strings.HasSuffix(execPath, "/envoy.test") {
+		return "", nil, fmt.Errorf("set execArgs to use 'go run' instead of doing a self-exec")
+	}
+
+	return execPath, args, nil
+}

--- a/command/connect/envoy/exec_unix.go
+++ b/command/connect/envoy/exec_unix.go
@@ -16,56 +16,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// testSelfExecOverride is a way for the tests to no fork-bomb themselves by
-// self-executing the whole test suite for each case recursively. It's gross but
-// the least gross option I could think of.
-var testSelfExecOverride string
-
-func isHotRestartOption(s string) bool {
-	restartOpts := []string{
-		"--restart-epoch",
-		"--hot-restart-version",
-		"--drain-time-s",
-		"--parent-shutdown-time-s",
-	}
-	for _, opt := range restartOpts {
-		if s == opt {
-			return true
-		}
-		if strings.HasPrefix(s, opt+"=") {
-			return true
-		}
-	}
-	return false
-}
-
-func hasHotRestartOption(argSets ...[]string) bool {
-	for _, args := range argSets {
-		for _, opt := range args {
-			if isHotRestartOption(opt) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// execArgs returns the command and args used to execute a binary. By default it
-// will return a command of os.Executable with the args unmodified. This is a shim
-// for testing, and can be overridden to execute using 'go run' instead.
-var execArgs = func(args ...string) (string, []string, error) {
-	execPath, err := os.Executable()
-	if err != nil {
-		return "", nil, err
-	}
-
-	if strings.HasSuffix(execPath, "/envoy.test") {
-		return "", nil, fmt.Errorf("set execArgs to use 'go run' instead of doing a self-exec")
-	}
-
-	return execPath, args, nil
-}
-
 func makeBootstrapPipe(bootstrapJSON []byte) (string, error) {
 	pipeFile := filepath.Join(os.TempDir(),
 		fmt.Sprintf("envoy-%x-bootstrap.json", time.Now().UnixNano()+int64(os.Getpid())))

--- a/command/connect/envoy/exec_windows.go
+++ b/command/connect/envoy/exec_windows.go
@@ -10,44 +10,9 @@ import (
 	"os/exec"
 
 	"path/filepath"
-	"strings"
 
 	"time"
 )
-
-// testSelfExecOverride is a way for the tests to no fork-bomb themselves by
-// self-executing the whole test suite for each case recursively. It's gross but
-// the least gross option I could think of.
-var testSelfExecOverride string
-
-func isHotRestartOption(s string) bool {
-	restartOpts := []string{
-		"--restart-epoch",
-		"--hot-restart-version",
-		"--drain-time-s",
-		"--parent-shutdown-time-s",
-	}
-	for _, opt := range restartOpts {
-		if s == opt {
-			return true
-		}
-		if strings.HasPrefix(s, opt+"=") {
-			return true
-		}
-	}
-	return false
-}
-
-func hasHotRestartOption(argSets ...[]string) bool {
-	for _, args := range argSets {
-		for _, opt := range args {
-			if isHotRestartOption(opt) {
-				return true
-			}
-		}
-	}
-	return false
-}
 
 func makeBootstrapTemp(bootstrapJSON []byte) (string, error) {
 	tempFile := filepath.Join(os.TempDir(),

--- a/command/registry.go
+++ b/command/registry.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"runtime"
 	"syscall"
 
 	"github.com/hashicorp/consul/command/acl"
@@ -126,8 +125,6 @@ import (
 	"github.com/hashicorp/consul/command/cli"
 )
 
-const OSPlatform = runtime.GOOS
-
 // RegisteredCommands returns a realized mapping of available CLI commands in a format that
 // the CLI class can consume.
 func RegisteredCommands(ui cli.Ui) map[string]mcli.CommandFactory {
@@ -183,7 +180,7 @@ func RegisteredCommands(ui cli.Ui) map[string]mcli.CommandFactory {
 		entry{"connect ca get-config", func(ui cli.Ui) (cli.Command, error) { return caget.New(ui), nil }},
 		entry{"connect ca set-config", func(ui cli.Ui) (cli.Command, error) { return caset.New(ui), nil }},
 		entry{"connect proxy", func(ui cli.Ui) (cli.Command, error) { return proxy.New(ui, MakeShutdownCh()), nil }},
-		entry{"connect envoy", func(ui cli.Ui) (cli.Command, error) { return envoy.New(ui, OSPlatform), nil }},
+		entry{"connect envoy", func(ui cli.Ui) (cli.Command, error) { return envoy.New(ui), nil }},
 		entry{"connect envoy pipe-bootstrap", func(ui cli.Ui) (cli.Command, error) { return pipebootstrap.New(ui), nil }},
 		entry{"connect expose", func(ui cli.Ui) (cli.Command, error) { return expose.New(ui), nil }},
 		entry{"connect redirect-traffic", func(ui cli.Ui) (cli.Command, error) { return redirecttraffic.New(ui), nil }},


### PR DESCRIPTION
### Description
Created exec_supported.go to avoid code duplication. We've collected the shared functions and variables between exec_windows.go and exec_unix.go in this file. Now  exec_windows and exec_unix only contain code for their respective platforms.